### PR TITLE
Add LTK (Lunctoken) token metadata to cw20 registry

### DIFF
--- a/cw20/tokens/mainnet/terra.js
+++ b/cw20/tokens/mainnet/terra.js
@@ -2157,7 +2157,7 @@ module.exports = [
         icon: "https://i.ibb.co.com/Z63cbqDM/Garuda-67.png",
         decimals: 6,
     },
-        {
+    {
         protocol : "Lunctoken",
         name: "Lunctoken",
         symbol: "LTK",

--- a/cw20/tokens/mainnet/terra.js
+++ b/cw20/tokens/mainnet/terra.js
@@ -2157,4 +2157,12 @@ module.exports = [
         icon: "https://i.ibb.co.com/Z63cbqDM/Garuda-67.png",
         decimals: 6,
     },
+        {
+        protocol : "Lunctoken",
+        name: "Lunctoken",
+        symbol: "LTK",
+        token: "terra1mm8tdp40r2slzwqxk8jsz66ayc4zp69muxeateq37x2xquttzsaqy7275a",
+        icon: "https://i.ibb.co/gL8fMHdF/logo-ltk-lunctoken-256x256.png",
+        decimals: 6,
+    },
 ]


### PR DESCRIPTION
This PR adds the Lunctoken (LTK) token metadata to the cw20 registry, under `cw20/tokens/mainnet/terra.js`.

Token details:
- Name: Lunctoken
- Symbol: LTK
- Chain: Terra Classic (columbus-5)
- CW20 Address: terra1mm8tdp40r2slzwqxk8jsz66ayc4zp69muxeateq37x2xquttzsaqy7275a
- Decimals: 6
- Website: https://www.lunctoken.org
